### PR TITLE
Add random query

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Options:
 -r, --bearerToken string   Bearer token of your org to ingest (default "")
 -n, --numIterations int    Number of iterations to send query suite (default 10)
 -f, --filePath string      path to csv file containing query suite to send to server. Expects CSV of with [search text, startTime, endTime, indexName, evaluation type, relation, count, queryLanguage] in each row
+    --randomQueries bool   Generate random queries (default false)
 -v  verbose                Output hits and elapsed time for each query
 -c  continuous             If true, ignores -n and -v and will continuously send queries to the destination and will log results
 ```

--- a/cmd/sigclient.go
+++ b/cmd/sigclient.go
@@ -83,6 +83,7 @@ var esQueryCmd = &cobra.Command{
 		continuous, _ := cmd.Flags().GetBool("continuous")
 		indexPrefix, _ := cmd.Flags().GetString("indexPrefix")
 		filepath, _ := cmd.Flags().GetString("filePath")
+		randomQueries, _ := cmd.Flags().GetBool("randomQueries")
 		bearerToken, _ := cmd.Flags().GetString("bearerToken")
 
 		log.Infof("dest : %+v\n", dest)
@@ -91,11 +92,12 @@ var esQueryCmd = &cobra.Command{
 		log.Infof("verbose : %+v\n", verbose)
 		log.Infof("continuous : %+v\n", continuous)
 		log.Infof("filePath : %+v\n", filepath)
+		log.Infof("randomQueries: %+v\n", randomQueries)
 		log.Infof("bearerToken : %+v\n", bearerToken)
 		if filepath != "" {
 			query.RunQueryFromFile(dest, numIterations, indexPrefix, continuous, verbose, filepath, bearerToken)
 		} else {
-			query.StartQuery(dest, numIterations, indexPrefix, continuous, verbose, bearerToken)
+			query.StartQuery(dest, numIterations, indexPrefix, continuous, verbose, randomQueries, bearerToken)
 		}
 	},
 }
@@ -187,6 +189,7 @@ func init() {
 	queryCmd.PersistentFlags().BoolP("continuous", "c", false, "Continuous querying will ignore -c and -v and will continuously send queries to the destination")
 	queryCmd.PersistentFlags().BoolP("validateMetricsOutput", "y", false, "check if metric querries return any results")
 	queryCmd.PersistentFlags().StringP("filePath", "f", "", "filepath to csv file to use to run queries from")
+	queryCmd.PersistentFlags().BoolP("randomQueries", "", false, "generate random queries")
 
 	queryCmd.AddCommand(esQueryCmd)
 	queryCmd.AddCommand(metricsQueryCmd)

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -314,7 +314,7 @@ func getRandomQuery() []byte {
 	time1day := time - (1 * 24 * 60 * 60 * 1000)
 
 	must := make([]interface{}, 0)
-	mustNot := make([]interface{}, 0)
+	// mustNot := make([]interface{}, 0)
 	should := make([]interface{}, 0)
 
 	numConditions := faker.Number(1, 5)
@@ -404,12 +404,12 @@ func getRandomQuery() []byte {
 			}
 		}
 
-		switch faker.Number(0, 2) {
+		switch faker.Number(0, 1) {
 		case 0:
 			must = append(must, condition)
+		// case 1:
+		// 	mustNot = append(mustNot, condition)
 		case 1:
-			mustNot = append(mustNot, condition)
-		case 2:
 			should = append(should, condition)
 		}
 	}
@@ -418,7 +418,7 @@ func getRandomQuery() []byte {
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{
 				"must":   must,
-				"must_not": mustNot,
+				// "must_not": mustNot,
 				"should": should,
 				"filter": []interface{}{
 					map[string]interface{}{

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -311,11 +311,12 @@ func getFreeTextSearch() []byte {
 func getRandomQuery() []byte {
 	faker := gofakeit.NewUnlocked(time.Now().UnixNano())
 	time := time.Now().UnixMilli()
-	time1day := time - (1 * 24 * 60 * 60 * 1000)
+	time1day := time - (7 * 24 * 60 * 60 * 1000)
 
 	must := make([]interface{}, 0)
 	// mustNot := make([]interface{}, 0)
 	should := make([]interface{}, 0)
+	used_string_column := [8]bool{}
 
 	numConditions := faker.Number(1, 5)
 	for i := 0; i < numConditions; i++ {
@@ -325,7 +326,8 @@ func getRandomQuery() []byte {
 		// Create the condition. See randomizeBody() in reader.go for how
 		// column values are generated.
 		var column string
-		if faker.Number(0, 12) < 3 {
+//		if faker.Number(0, 12) < 3 {
+		if false {
 			// Query a numeric column.
 			var inequality string
 			if faker.Bool() {
@@ -366,7 +368,15 @@ func getRandomQuery() []byte {
 		} else {
 			// Query a string column.
 			var value string
-			switch faker.Number(0, 8) {
+
+			// Choose a column we haven't used in this query yet.
+			colInd := faker.Number(0, 7)
+			for ; used_string_column[colInd] ; {
+				colInd = faker.Number(0, 7)
+			}
+			used_string_column[colInd] = true
+
+			switch colInd {
 			case 0:
 				column = "batch"
 				value = "batch-" + fmt.Sprintf("%v", faker.Number(1, 1000))
@@ -380,18 +390,15 @@ func getRandomQuery() []byte {
 				column = "gender"
 				value = faker.Person().Gender
 			case 4:
-				column = "group"
-				value = "group " + fmt.Sprintf("%v", faker.Number(0, 2))
-			case 5:
 				column = "http_method"
 				value = faker.HTTPMethod()
-			case 6:
+			case 5:
 				column = "state"
 				value = faker.Person().Address.State
-			case 7:
+			case 6:
 				column = "user_color"
 				value = faker.Color()
-			case 8:
+			case 7:
 				column = "weekday"
 				value = faker.WeekDay()
 			}
@@ -439,7 +446,7 @@ func getRandomQuery() []byte {
 	if err != nil {
 		log.Fatalf("error marshalling query: %+v", err)
 	}
-	log.Errorf("created random query: %v", string(raw))
+//	log.Errorf("created random query: %v", string(raw))
 	return raw
 }
 


### PR DESCRIPTION
This adds a `--randomQueries` flag to the `query` command which configures the client to generate a new random query each time. The query is generated assuming that the existing data that will be searched was ingested using the randomly generated ingestion data (e.g., `ingest` with `dynamic-user`)