### PR TITLE
Csv query comparison for string

### DIFF
--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -378,7 +378,7 @@ func getRandomQuery() []byte {
 	var matchAllQuery = map[string]interface{}{
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{
-				"must": must,
+				"must":   must,
 				"should": should,
 				"filter": []interface{}{
 					map[string]interface{}{


### PR DESCRIPTION
This allows us to compare two strings when we run CI/CD tests to read a .csv file.
For example: 
- city=Boston | stats count AS Count BY weekday | eval lower=lower(weekday),now-1d,now,*,group:lower:Thursday,eq,thursday,Splunk QL
- "city=Boston | stats count AS Count BY state | eval myField=""test "" . ""start:"" . rtrim(state, ""nd"")",now-1d,now,*,group:myField:Maryland,eq,test start:Maryla,Splunk QL

