### PR TITLE
Fix typo in traces ingest commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Options:
 
 To send ingestion traffic to a server using ES Bulk API:
 ```bash
-$ go run main.go ingest -t 1000 -d http://localhost:8081/elastic -g file -x {filePrefix}_services.json --indexName jaeger-service-YYYY-MM-DD
-$ go run main.go ingest -t 1000 -d http://localhost:8081/elastic -g file -x {filePrefix}_spans.json --indexName jaeger-span-YYYY-MM--DD
+$ go run main.go ingest esbulk -t 1000 -d http://localhost:8081/elastic -g file -x {filePrefix}_services.json --indexName jaeger-service-YYYY-MM-DD
+$ go run main.go ingest esbulk -t 1000 -d http://localhost:8081/elastic -g file -x {filePrefix}_spans.json --indexName jaeger-span-YYYY-MM-DD
 ```
 
 Options:


### PR DESCRIPTION
The commands for ingesting traces from a file after generating fake traces were not correct, so if you ran the commands in the README you'd get a usage error.