### PR TITLE
Fix skipping first and last line in file ingestion

### DIFF
--- a/pkg/utils/reader.go
+++ b/pkg/utils/reader.go
@@ -308,7 +308,7 @@ func (fr *FileReader) Init(fName ...string) error {
 func (fr *FileReader) GetLogLine() ([]byte, error) {
 	fr.editLock.Lock()
 	defer fr.editLock.Unlock()
-	if fr.currIdx >= len(fr.logLines)-1 {
+	if fr.currIdx >= len(fr.logLines) {
 		err := fr.prefetchChunk(false)
 		if err != nil {
 			return []byte{}, err
@@ -378,7 +378,7 @@ func (fr *FileReader) prefetchChunk(override bool) error {
 	tmpMap := make(map[string]interface{})
 	lNum := 0
 	for fileScanner.Scan() {
-		if lNum <= fr.lineNum {
+		if lNum < fr.lineNum {
 			lNum++
 			continue
 		}


### PR DESCRIPTION
# Description
This fixes an issue with ingesting data from a file where the first and last lines would be skipped. With these fixes, if you set `-t` (`totalEvents`) to the number of events in the file and use `-p 1` (so it's single-threaded), all of the events should get ingested just once.

For multi-threaded jobs, all the file readers start ingesting at line 0, so you'll get repeats of the first several lines and none of the later lines (assuming each thread ingests fewer events than the number of lines in the file)--this behavior was not changed in this PR.

# Testing
I tested this by first making a file `test.json` with 10 JSON entries:
```
{"cab_type": "yellow0"}
{"cab_type": "yellow1"}
{"cab_type": "yellow2"}
{"cab_type": "yellow3"}
{"cab_type": "yellow4"}
{"cab_type": "yellow5"}
{"cab_type": "yellow6"}
{"cab_type": "yellow7"}
{"cab_type": "yellow8"}
{"cab_type": "yellow9"}
```
Then starting siglens (with a clear `data/` directory). Then in sigscalr-client I ran
```
go run main.go ingest esbulk -d http://localhost:8081/elastic -p 1 -g file -x "benchdata/test.json" -t 10 -b 500
```
And verified that each line was ingested once. I also check that ingesting fewer or more than 10 events behaves as expected and restarts from the beginning of the file when there's more than 10 events ingested.